### PR TITLE
Set cert suite pod's owner reference to be corresponding run CR

### DIFF
--- a/internal/controller/cnf-cert-job/cnfcertjob.go
+++ b/internal/controller/cnf-cert-job/cnfcertjob.go
@@ -5,6 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/test-network-function/cnf-certsuite-operator/internal/controller/definitions"
 )
@@ -240,6 +241,19 @@ func WithEnableDataCollection(enableDataCollection string) func(*corev1.Pod) err
 			return fmt.Errorf("cnf cert suite Container is not found in pod %s", p.Name)
 		}
 		cnfCertSuiteContainer.Env = append(cnfCertSuiteContainer.Env, envVar)
+		return nil
+	}
+}
+
+func WithOwnerReference(ownerUID types.UID, ownerName, ownerKind, ownerAPIVersion string) func(*corev1.Pod) error {
+	return func(p *corev1.Pod) error {
+		ownerReference := &metav1.OwnerReference{
+			APIVersion: ownerAPIVersion,
+			Kind:       ownerKind,
+			Name:       ownerName,
+			UID:        ownerUID,
+		}
+		p.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*ownerReference}
 		return nil
 	}
 }

--- a/internal/controller/cnfcertificationsuiterun_controller.go
+++ b/internal/controller/cnfcertificationsuiterun_controller.go
@@ -253,6 +253,7 @@ func (r *CnfCertificationSuiteRunReconciler) Reconcile(ctx context.Context, req 
 		cnfcertjob.WithPreflightSecret(runCR.Spec.PreflightSecretName),
 		cnfcertjob.WithSideCarApp(sideCarImage),
 		cnfcertjob.WithEnableDataCollection(strconv.FormatBool(runCR.Spec.EnableDataCollection)),
+		cnfcertjob.WithOwnerReference(runCR.UID, runCR.Name, runCR.Kind, runCR.APIVersion),
 	)
 	if err != nil {
 		logger.Errorf("Failed to create CNF Cert job pod spec: %w", err)


### PR DESCRIPTION
The run CR  is set as the owner of the cnf cert suite pod created when reconcile function was triggered.
That so, if the CR is deleted, the pod will also be deleted.