### PR TITLE
Show non-compliant and compliant resources in Status.Report.Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ It can be modified by changing manually the `labelsFilter` of the [sample CR](ht
         - **showAllResultsLogs**: Set to "true" to show all result's logs,
         and not only logs of failed test cases.
         This field is set to "false" by default.
+        - **showCompliantResourcesAlways**: Set to "true" to show compliant
+        resources of all results. and not only compliant and non-compliant
+        resources of failed test cases. This field is set to "false" by default.
 
         See a [sample CnfCertificationSuiteRun CR](https://github.com/greyerof/tnf-op/blob/main/config/samples/cnf-certifications_v1alpha1_cnfcertificationsuiterun.yaml)
 

--- a/api/v1alpha1/cnfcertificationsuiterun_types.go
+++ b/api/v1alpha1/cnfcertificationsuiterun_types.go
@@ -44,6 +44,8 @@ type CnfCertificationSuiteRunSpec struct {
 	EnableDataCollection bool `json:"enableDataCollection,omitempty"`
 	// ShowAllResultsLogs is set to true for showing all test results logs, and not only of failed tcs.
 	ShowAllResultsLogs bool `json:"showAllResultsLogs,omitempty"`
+	// ShowCompliantResourcesAlways is set true for showing compliant resources for all ran tcs, and not only of failed tcs.
+	ShowCompliantResourcesAlways bool `json:"showCompliantResourcesAlways,omitempty"`
 }
 
 type StatusPhase string
@@ -106,12 +108,16 @@ type CnfCertificationSuiteReport struct {
 	Results             []TestCaseResult                         `json:"results"`
 }
 
+type TargetResource map[string]string
+
 // TestCaseResult holds a test case result
 type TestCaseResult struct {
-	TestCaseName string `json:"testCaseName"`
-	Result       string `json:"result"`
-	Reason       string `json:"reason,omitempty"`
-	Logs         string `json:"logs,omitempty"`
+	TestCaseName string           `json:"testCaseName"`
+	Result       string           `json:"result"`
+	Reason       string           `json:"reason,omitempty"`
+	Logs         string           `json:"logs,omitempty"`
+	Compliant    []TargetResource `json:"compliant,omitempty"`
+	NonCompliant []TargetResource `json:"nonCompliant,omitempty"`
 }
 
 type CnfCertificationSuiteReportStatusSummary struct {

--- a/api/v1alpha1/cnfcertificationsuiterun_types.go
+++ b/api/v1alpha1/cnfcertificationsuiterun_types.go
@@ -58,6 +58,20 @@ const (
 	StatusPhaseCertSuiteError       = "CertSuiteError"
 )
 
+const (
+	StatusStatePassed  = "passed"
+	StatusStateSkipped = "skipped"
+	StatusStateFailed  = "failed"
+	StatusStateError   = "error"
+)
+
+const (
+	StatusVerdictPass  = "pass"
+	StatusVerdictSkip  = "skip"
+	StatusVerdictFail  = "fail"
+	StatusVerdictError = "error"
+)
+
 // CnfCertificationSuiteRunStatus defines the observed state of CnfCertificationSuiteRun
 type CnfCertificationSuiteRunStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
@@ -100,6 +114,7 @@ type CnfCertificationSuiteReport struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	//+kubebuilder:validation:Enum=pass;skip;fail;error
 	Verdict             string                                   `json:"verdict"`
 	OcpVersion          string                                   `json:"ocpVersion"`
 	CnfCertSuiteVersion string                                   `json:"cnfCertSuiteVersion"`
@@ -110,14 +125,19 @@ type CnfCertificationSuiteReport struct {
 
 type TargetResource map[string]string
 
-// TestCaseResult holds a test case result
-type TestCaseResult struct {
-	TestCaseName string           `json:"testCaseName"`
-	Result       string           `json:"result"`
-	Reason       string           `json:"reason,omitempty"`
-	Logs         string           `json:"logs,omitempty"`
+type TargetResources struct {
 	Compliant    []TargetResource `json:"compliant,omitempty"`
 	NonCompliant []TargetResource `json:"nonCompliant,omitempty"`
+}
+
+// TestCaseResult holds a test case result
+type TestCaseResult struct {
+	TestCaseName string `json:"testCaseName"`
+	//+kubebuilder:validation:Enum=passed;skipped;failed;error
+	Result          string           `json:"result"`
+	Reason          string           `json:"reason,omitempty"`
+	Logs            string           `json:"logs,omitempty"`
+	TargetResources *TargetResources `json:"targetResources,omitempty"`
 }
 
 type CnfCertificationSuiteReportStatusSummary struct {

--- a/cnf-cert-sidecar/app/claim/claim.go
+++ b/cnf-cert-sidecar/app/claim/claim.go
@@ -43,6 +43,7 @@ type TestCaseResult struct {
 		Remediation           string `json:"remediation"`
 	} `json:"catalogInfo"`
 	CategoryClassification map[string]string `json:"categoryClassification"`
+	CheckDetails           string            `json:"checkDetails"`
 	Duration               int               `json:"duration"`
 	EndTime                string            `json:"endTime"`
 	FailureLineContent     string            `json:"failureLineContent"`

--- a/cnf-cert-sidecar/app/main.go
+++ b/cnf-cert-sidecar/app/main.go
@@ -81,7 +81,7 @@ func handleClaimFile(k8sClient client.Client) {
 			logrus.Fatalf("Failed to update CnfCertificationSuiteRun.Status object object: %v", err)
 		}
 
-		logrus.Infof("CnfCertificationSuiteRun CR's status updated successfully with results:\n%s", runCR.Status.Report.Results)
+		logrus.Infof("CnfCertificationSuiteRun CR's status updated successfully with results:\n%v", runCR.Status.Report.Results)
 		break
 	}
 }

--- a/config/crd/bases/cnf-certifications.redhat.com_cnfcertificationsuiteruns.yaml
+++ b/config/crd/bases/cnf-certifications.redhat.com_cnfcertificationsuiteruns.yaml
@@ -70,6 +70,10 @@ spec:
                 description: ShowAllResultsLogs is set to true for showing all test
                   results logs, and not only of failed tcs.
                 type: boolean
+              showCompliantResourcesAlways:
+                description: ShowCompliantResourcesAlways is set true for showing
+                  compliant resources for all ran tcs, and not only of failed tcs.
+                type: boolean
               timeout:
                 description: Total timeout for the CNF Cert Suite to run.
                 type: string
@@ -182,8 +186,20 @@ spec:
                     items:
                       description: TestCaseResult holds a test case result
                       properties:
+                        compliant:
+                          items:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          type: array
                         logs:
                           type: string
+                        nonCompliant:
+                          items:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          type: array
                         reason:
                           type: string
                         result:

--- a/config/crd/bases/cnf-certifications.redhat.com_cnfcertificationsuiteruns.yaml
+++ b/config/crd/bases/cnf-certifications.redhat.com_cnfcertificationsuiteruns.yaml
@@ -186,24 +186,32 @@ spec:
                     items:
                       description: TestCaseResult holds a test case result
                       properties:
-                        compliant:
-                          items:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          type: array
                         logs:
                           type: string
-                        nonCompliant:
-                          items:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          type: array
                         reason:
                           type: string
                         result:
+                          enum:
+                          - passed
+                          - skipped
+                          - failed
+                          - error
                           type: string
+                        targetResources:
+                          properties:
+                            compliant:
+                              items:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              type: array
+                            nonCompliant:
+                              items:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              type: array
+                          type: object
                         testCaseName:
                           type: string
                       required:
@@ -231,6 +239,11 @@ spec:
                     - total
                     type: object
                   verdict:
+                    enum:
+                    - pass
+                    - skip
+                    - fail
+                    - error
                     type: string
                 required:
                 - cnfCertSuiteVersion

--- a/config/samples/cnf-certifications_v1alpha1_cnfcertificationsuiterun.yaml
+++ b/config/samples/cnf-certifications_v1alpha1_cnfcertificationsuiterun.yaml
@@ -19,3 +19,4 @@ spec:
   preflightSecretName : "cnf-certsuite-preflight-dockerconfig"
   enableDataCollection: false
   showAllResultsLogs: false
+  showCompliantResourcesAlways: false


### PR DESCRIPTION
This PR adds non-complaint and compliant resources to the Status.Report.Results.
By default, those resources will be added only to failed tcs.
In order to show also complaint, the `showCompliantResourcesAlways` run CR's spec field must be set to "true" manually.

Also, the field was added to the run CR sample, and an explanation regarding this field was added to the README.md file.