### PR TITLE
Ensure getting exit status doesn't return an error

### DIFF
--- a/internal/controller/cnfcertificationsuiterun_controller.go
+++ b/internal/controller/cnfcertificationsuiterun_controller.go
@@ -133,7 +133,7 @@ func (r *CnfCertificationSuiteRunReconciler) waitForCertSuitePodToComplete(certS
 		certSuitePod := corev1.Pod{}
 		err = r.Get(context.TODO(), certSuitePodNamespacedName, &certSuitePod)
 		if err != nil {
-			return -1, err
+			return 0, err
 		}
 
 		switch certSuitePod.Status.Phase {
@@ -144,7 +144,7 @@ func (r *CnfCertificationSuiteRunReconciler) waitForCertSuitePodToComplete(certS
 			logger.Info("Cnf job pod has completed with failure.")
 			exitStatus, err := getCertSuiteContainerExitStatus(&certSuitePod)
 			if err != nil {
-				return -1, err
+				return 0, err
 			}
 			return exitStatus, nil
 		default:
@@ -153,7 +153,7 @@ func (r *CnfCertificationSuiteRunReconciler) waitForCertSuitePodToComplete(certS
 		}
 	}
 
-	return -1, fmt.Errorf("timeout (%s) reached while waiting for cert suite pod %v to finish", timeOut, certSuitePodNamespacedName)
+	return 0, fmt.Errorf("timeout (%s) reached while waiting for cert suite pod %v to finish", timeOut, certSuitePodNamespacedName)
 }
 
 func getCertSuiteContainerExitStatus(certSuitePod *corev1.Pod) (int32, error) {
@@ -164,7 +164,7 @@ func getCertSuiteContainerExitStatus(certSuitePod *corev1.Pod) (int32, error) {
 		}
 	}
 
-	return -1, fmt.Errorf("failed to get cert suite exit status: container not found in pod %s (ns %s)", certSuitePod.Name, certSuitePod.Namespace)
+	return 0, fmt.Errorf("failed to get cert suite exit status: container not found in pod %s (ns %s)", certSuitePod.Name, certSuitePod.Namespace)
 }
 
 func (r *CnfCertificationSuiteRunReconciler) handleEndOfCnfCertSuiteRun(runCrName, certSuitePodName, namespace, reqTimeout string) {

--- a/internal/controller/cnfcertificationsuiterun_controller.go
+++ b/internal/controller/cnfcertificationsuiterun_controller.go
@@ -133,7 +133,7 @@ func (r *CnfCertificationSuiteRunReconciler) waitForCertSuitePodToComplete(certS
 		certSuitePod := corev1.Pod{}
 		err = r.Get(context.TODO(), certSuitePodNamespacedName, &certSuitePod)
 		if err != nil {
-			return 0, err
+			return -1, err
 		}
 
 		switch certSuitePod.Status.Phase {
@@ -142,26 +142,29 @@ func (r *CnfCertificationSuiteRunReconciler) waitForCertSuitePodToComplete(certS
 			return 0, nil
 		case corev1.PodFailed:
 			logger.Info("Cnf job pod has completed with failure.")
-			return getCertSuiteContainerExitStatus(&certSuitePod), nil
+			exitStatus, err := getCertSuiteContainerExitStatus(&certSuitePod)
+			if err != nil {
+				return -1, err
+			}
+			return exitStatus, nil
 		default:
 			logger.Infof("Cnf job pod is running. Current status: %s", certSuitePod.Status.Phase)
 			time.Sleep(checkInterval)
 		}
 	}
 
-	return 0, fmt.Errorf("timeout (%s) reached while waiting for cert suite pod %v to finish", timeOut, certSuitePodNamespacedName)
+	return -1, fmt.Errorf("timeout (%s) reached while waiting for cert suite pod %v to finish", timeOut, certSuitePodNamespacedName)
 }
 
-func getCertSuiteContainerExitStatus(certSuitePod *corev1.Pod) int32 {
+func getCertSuiteContainerExitStatus(certSuitePod *corev1.Pod) (int32, error) {
 	for i := range certSuitePod.Status.ContainerStatuses {
 		containerStatus := &certSuitePod.Status.ContainerStatuses[i]
 		if containerStatus.Name == definitions.CnfCertSuiteContainerName {
-			return containerStatus.State.Terminated.ExitCode
+			return containerStatus.State.Terminated.ExitCode, nil
 		}
 	}
 
-	logger.Errorf("Failed to get cert suite exit status: container not found in pod %s (ns %s)", certSuitePod.Name, certSuitePod.Namespace)
-	return -1
+	return -1, fmt.Errorf("failed to get cert suite exit status: container not found in pod %s (ns %s)", certSuitePod.Name, certSuitePod.Namespace)
 }
 
 func (r *CnfCertificationSuiteRunReconciler) handleEndOfCnfCertSuiteRun(runCrName, certSuitePodName, namespace, reqTimeout string) {


### PR DESCRIPTION
This PR adds an error as a return value from `getCertSuiteContainerExitStatus` function in order to ensure no errors have occurred (the container wasn't found). 