### PR TITLE
Set console plugin ns dynamically

### DIFF
--- a/bundle/manifests/cnf-certsuite-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/cnf-certsuite-operator.clusterserviceversion.yaml
@@ -125,6 +125,10 @@ spec:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: SIDECAR_APP_IMG
                   value: quay.io/testnetworkfunction/cnf-certsuite-operator-sidecar:v0.0.1
+                - name: CONTROLLER_NS
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 image: quay.io/testnetworkfunction/cnf-certsuite-operator:v0.0.1
                 imagePullPolicy: IfNotPresent
                 livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,6 +77,10 @@ spec:
               fieldPath: metadata.namespace
         - name: SIDECAR_APP_IMG
           value: quay.io/testnetworkfunction/cnf-certsuite-operator-sidecar:v0.0.1
+        - name: CONTROLLER_NS
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: controller:latest
         name: manager
         imagePullPolicy: IfNotPresent

--- a/internal/controller/definitions/definitions.go
+++ b/internal/controller/definitions/definitions.go
@@ -22,6 +22,6 @@ const (
 	PreflightDockerConfigFilePath = CnfPreflightConfigFolder + "/preflight_dockerconfig.json"
 
 	SideCarResultsFolderEnvVar = "TNF_RESULTS_FOLDER"
-
-	SideCarImageEnvVar = "SIDECAR_APP_IMG"
+	SideCarImageEnvVar         = "SIDECAR_APP_IMG"
+	ControllerNamespaceEnvVar  = "CONTROLLER_NS"
 )

--- a/plugin/configmap.yaml
+++ b/plugin/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx-configmap
-  namespace: cnf-certsuite-operator
+  namespace: OPERATOR_NS_PLACEHOLDER
   labels:
     app: cnf-certsuite-plugin
     app.kubernetes.io/component: cnf-certsuite-plugin

--- a/plugin/console-plugin.yaml
+++ b/plugin/console-plugin.yaml
@@ -2,7 +2,7 @@ apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
 metadata:
   name: cnf-certsuite-plugin
-  namespace: cnf-certsuite-operator
+  namespace: OPERATOR_NS_PLACEHOLDER
   labels:
     app: cnf-certsuite-plugin
     app.kubernetes.io/component: cnf-certsuite-plugin

--- a/plugin/deployment.yaml
+++ b/plugin/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cnf-certsuite-plugin
-  namespace: cnf-certsuite-operator
+  namespace: OPERATOR_NS_PLACEHOLDER
   labels:
     app: cnf-certsuite-plugin
     app.kubernetes.io/component: cnf-certsuite-plugin

--- a/plugin/service.yaml
+++ b/plugin/service.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: console-serving-cert
   name: cnf-certsuite-plugin
-  namespace: cnf-certsuite-operator
+  namespace: OPERATOR_NS_PLACEHOLDER
   labels:
     app: cnf-certsuite-plugin
     app.kubernetes.io/component: cnf-certsuite-plugin


### PR DESCRIPTION
Based on [this](https://github.com/test-network-function/cnf-certsuite-operator/pull/89#discussion_r1681039870) discussion in previous PR, Instead of using a hard coded ns for the console plugin, the plugin ns will be set according to the ns of the controller. 

The controller ns is saved as an env var within the container using [downward API](https://github.com/kubernetes/kubernetes/blob/release-1.0/docs/user-guide/downward-api.md).
That way, when setting up controller's manager and creating the plugin resources, we can extract the controller's ns and set it as the console plugin ns as well.

The plugin resources don't have a default ns, and are set with a place holder for the ns. That way, if we fail to set the operator ns as the plugins ns, will get back an error.