### PR TITLE
Use kubectl command instead of oc in workflows using kind

### DIFF
--- a/.github/workflows/cnfcertificationsuiterun_validation_test.yaml
+++ b/.github/workflows/cnfcertificationsuiterun_validation_test.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Install cert-manager to cluster
         run: |
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
-          oc wait --for=condition=ready pod --all=true -n cert-manager --timeout=5m
+          kubectl wait --for=condition=ready pod --all=true -n cert-manager --timeout=5m
 
       - name: Install consoleplugin CRD to cluster
         run: |

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -169,7 +169,7 @@ jobs:
       - name: Install cert-manager to cluster
         run: |
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
-          oc wait --for=condition=ready pod --all=true -n cert-manager --timeout=5m
+          kubectl wait --for=condition=ready pod --all=true -n cert-manager --timeout=5m
       
       - name: Install consoleplugin CRD to cluster
         run: |


### PR DESCRIPTION
Addressing [this](https://github.com/test-network-function/cnf-certsuite-operator/pull/89#discussion_r1681123412) discussion in previous PR. 

For terms of consistency we'll use only the `kubectl` command instead of  `oc` command when running workflows using a kind cluster.